### PR TITLE
Import version 0.8.1 from amo

### DIFF
--- a/src/chrome/content/calendarCreation.xul
+++ b/src/chrome/content/calendarCreation.xul
@@ -45,8 +45,11 @@
 ]>
 
 <overlay id="cTBD_calendarCreation" xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
-    <wizard id="calendar-wizard" onload="cTBD_loadCalendarCreation();">
+    <wizard id="calendar-wizard">
         <script type="application/x-javascript" src="chrome://thunderbirthday/content/calendarCreation.js"/>
+        <script type="application/javascript"><![CDATA[
+          window.addEventListener("load", cTBD_loadCalendarCreation, false);
+        ]]></script>
         
         <wizardpage pageid="cTBD_locationPageLocal"
                    next="customizePage"

--- a/src/install.rdf
+++ b/src/install.rdf
@@ -41,7 +41,7 @@
     
     <Description about="urn:mozilla:install-manifest">
         <em:id>{4C9FE6FE-2C83-11DC-90B4-DC8456D89593}</em:id>
-        <em:version>0.8.0</em:version>
+        <em:version>0.8.1</em:version>
         <em:type>2</em:type>
         
         <em:name>ThunderBirthDay</em:name>
@@ -80,13 +80,13 @@
                 <!-- Thunderbird -->
                 <em:id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id>
                 <em:minVersion>3.0</em:minVersion>
-                <em:maxVersion>8.*</em:maxVersion>
+                <em:maxVersion>31.*</em:maxVersion>
             </Description>
             <Description>
                 <!-- SeaMonkey -->
                 <em:id>{92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}</em:id>
                 <em:minVersion>2.0</em:minVersion>
-                <em:maxVersion>2.5.*</em:maxVersion>
+                <em:maxVersion>2.30.*</em:maxVersion>
             </Description>
         </em:targetApplication>
         
@@ -95,7 +95,7 @@
                 <!-- Lightning -->
                 <em:id>{e2fda1a4-762b-4020-b5ad-a41df1933103}</em:id>
                 <em:minVersion>1.0a1pre</em:minVersion>
-                <em:maxVersion>1.0.*</em:maxVersion>
+                <em:maxVersion>3.3.*</em:maxVersion>
             </Description>
         </em:requires>
     </Description>


### PR DESCRIPTION
Somehow the repo does not contain version 0.8.1 which is available on amo. This commit imports the source from amo.

Feel free to ignore if you already have this locally and just forgot to update the github repo. :wink: 
