### PR TITLE
Disable local caching

### DIFF
--- a/src/js/calThunderBirthDay.js
+++ b/src/js/calThunderBirthDay.js
@@ -100,6 +100,7 @@ calThunderBirthDay.prototype = {
                 return true;
             // Capabilities
             case "requiresNetwork":
+            case "cache.supported":
             case "capabilities.attachments.supported":
             case "capabilities.priority.supported":
             case "capabilities.tasks.supported":


### PR DESCRIPTION
This change removes the possibility to enable local caching in the calendar settings and disables it by default.

There have been some complaints about the current behaviour on [amo](https://addons.mozilla.org/thunderbird/addon/thunderbirthday/reviews/): 
The age is no longer displayed on the recurrent events, because Lightning
defaults to local caching and does only cache the initial event.

This pull request does indirectly depend on #1, as you cannot create a calendar without it.
