### PR TITLE
Added support for 7-Zip to the make file. If the normal 'zip' command fails, it will use 7-Zip instead.

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -37,9 +37,31 @@ fi
 XPIFILE="$GENDIR/thunderbirthday-$VERSION.xpi"
 rm -f "$XPIFILE"
 
-# Create XPI
+# Create XPI (02/05/2016 Dirk Busse - Added support for 7-Zip if normal 'zip' application fails.)
 cd "$SRCDIR"
 zip -r "$XPIFILE" . -x@"$ROOTDIR/.gitignore"
+if [ $? -eq 0 ]
+then
+    # Using zip was successful.
+    cd "$ROOTDIR"
+    zip "$XPIFILE" README.md
+else
+    # Using zip failed.
+    # Now check if 7-Zip exists.
+    echo "Using zip failed. Now trying 7-Zip."
+    if [ -f "/c/Programme/7-Zip/7z.exe" ]
+    then
+        "/c/Programme/7-Zip/7z.exe" a -tzip -r "$XPIFILE" .
+        cd "$ROOTDIR"
+        "/c/Programme/7-Zip/7z.exe" a -tzip "$XPIFILE" README.md
+    elif [ -f "/c/Programme (x86)/7-Zip/7z.exe" ]
+    then
+        "/c/Programme (x86)/7-Zip/7z.exe" a -tzip -r "$XPIFILE" .
+        cd "$ROOTDIR"
+        "/c/Programme (x86)/7-Zip/7z.exe" a -tzip "$XPIFILE" README.md
+    else
+        echo "No zip application found. Exiting..."
+        exit
+    fi
+fi
 
-cd "$ROOTDIR"
-zip "$XPIFILE" README.md


### PR DESCRIPTION
Hi Ingo,

I don't have Cygwin installed and didn't want to install it just for this project. But I have 7-Zip installed.
Therefore, I've added support for 7-Zip to your make file. It will only try to use 7-Zip if the normal `zip` command failed.
I don't know if this is something you want to have in your code base.

Best Regards,
   Dirk
