### PR TITLE
Support for strict mode (TB 60 compat)

### DIFF
--- a/src/chrome/content/calendarCreation.js
+++ b/src/chrome/content/calendarCreation.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /* ***** BEGIN LICENSE BLOCK *****
  * Version: MPL 1.1/GPL 2.0/LGPL 2.1
  *

--- a/src/components/calThunderBirthDayModule.js
+++ b/src/components/calThunderBirthDayModule.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /* ***** BEGIN LICENSE BLOCK *****
  * Version: MPL 1.1/GPL 2.0/LGPL 2.1
  *

--- a/src/defaults/preferences/install.js
+++ b/src/defaults/preferences/install.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /* ***** BEGIN LICENSE BLOCK *****
  * Version: MPL 1.1/GPL 2.0/LGPL 2.1
  *

--- a/src/defaults/preferences/user.js
+++ b/src/defaults/preferences/user.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /* ***** BEGIN LICENSE BLOCK *****
  * Version: MPL 1.1/GPL 2.0/LGPL 2.1
  *

--- a/src/install.rdf
+++ b/src/install.rdf
@@ -41,7 +41,7 @@
     
     <Description about="urn:mozilla:install-manifest">
         <em:id>{4C9FE6FE-2C83-11DC-90B4-DC8456D89593}</em:id>
-        <em:version>0.8.2</em:version>
+        <em:version>0.8.3</em:version>
         <em:type>2</em:type>
         
         <em:name>ThunderBirthDay</em:name>
@@ -52,7 +52,7 @@
         <em:contributor>www.icondrawer.com (icon)</em:contributor>
         <em:iconURL>chrome://thunderbirthday/content/icon.png</em:iconURL>
 
-        <em:contributor>klemens (https://github.com/klemens)</em:contributor>
+        <em:contributor>Klemens Schölhorn</em:contributor>
         
         <em:translator>agnetao (sv-SE)</em:translator>
         <em:translator>Ahmed (ar)</em:translator>
@@ -82,7 +82,7 @@
                 <!-- Thunderbird -->
                 <em:id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id>
                 <em:minVersion>3.0</em:minVersion>
-                <em:maxVersion>38.*</em:maxVersion>
+                <em:maxVersion>60.*</em:maxVersion>
             </Description>
             <Description>
                 <!-- SeaMonkey -->
@@ -97,7 +97,7 @@
                 <!-- Lightning -->
                 <em:id>{e2fda1a4-762b-4020-b5ad-a41df1933103}</em:id>
                 <em:minVersion>1.0a1pre</em:minVersion>
-                <em:maxVersion>4.0.*</em:maxVersion>
+                <em:maxVersion>6.2.*</em:maxVersion>
             </Description>
         </em:requires>
     </Description>

--- a/src/js/calThunderBirthDay.js
+++ b/src/js/calThunderBirthDay.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /* ***** BEGIN LICENSE BLOCK *****
  * Version: MPL 1.1/GPL 2.0/LGPL 2.1
  *
@@ -561,7 +563,7 @@ calThunderBirthDay.prototype = {
 
             // Load all cards from the directory
             while (abCardsEnum.hasMoreElements()) {
-                abCard = abCardsEnum.getNext()
+                var abCard = abCardsEnum.getNext()
                                     .QueryInterface(Components.interfaces
                                                               .nsIAbCard);
 
@@ -788,15 +790,15 @@ calThunderBirthDay.prototype = {
         
         // choose best field of the abCard for the title (one of these fields
         // (except nickname) has to be set for every card)
-        with (abCard) var possibleTitles = [getProperty("DisplayName", null),
-                                            getProperty("NickName", null),
-                                            ( getProperty("FirstName", null) && getProperty("LastName", null) ?
-                                              getProperty("FirstName", null) + " " + getProperty("LastName", null) :
-                                              null ),
-                                            getProperty("FirstName", null),
-                                            getProperty("LastName", null),
-                                            getProperty("PrimaryEmail", null),
-                                            getProperty("Company", null)]
+        var possibleTitles = [abCard.getProperty("DisplayName", null),
+                              abCard.getProperty("NickName", null),
+                              ( abCard.getProperty("FirstName", null) && abCard.getProperty("LastName", null) ?
+                                abCard.getProperty("FirstName", null) + " " + abCard.getProperty("LastName", null) :
+                                null ),
+                              abCard.getProperty("FirstName", null),
+                              abCard.getProperty("LastName", null),
+                              abCard.getProperty("PrimaryEmail", null),
+                              abCard.getProperty("Company", null)]
         for (var i = 0; i < possibleTitles.length; i++) {
             if (possibleTitles[i]) {
                 event.title = possibleTitles[i];
@@ -894,13 +896,11 @@ function cTBD_getOccurencesFromEvent(aEvent, aRangeStart, aRangeEnd) {
     for (var i = 0; i < occurrences.length; i++) {
         occurrences[i] = occurrences[i].clone();
         
-        with (occurrences[i]) {
-            // append age to the title
-            var age = startDate.year - aEvent.startDate.year;
-            title += " (" + age + ")";
-            
-            makeImmutable();
-        }
+        // append age to the title
+        var age = occurrences[i].startDate.year - aEvent.startDate.year;
+        occurrences[i].title += " (" + age + ")";
+
+        occurrences[i].makeImmutable();
     }
     
     return occurrences;
@@ -943,29 +943,29 @@ function cTBD_compareDatesInYear(aDateTime1, aDateTime2) {
  * @param aMessage      Message to be logged
  */
 function MyLOG(aPriority, aMessage) {
-    if (this.mVerbosity == null) {
+    if (MyLOG.mVerbosity == null) {
         // load verbosity from pref tree
-        this.mVerbosity = Components.classes["@mozilla.org/preferences-service;1"]
+        MyLOG.mVerbosity = Components.classes["@mozilla.org/preferences-service;1"]
                                 .getService(Components.interfaces.nsIPrefService)
                                 .getBranch("extensions.thunderbirthday.")
                                 .getIntPref("verbosity");
         
         // load console service
-        this.mConsoleService = Components.classes["@mozilla.org/consoleservice;1"]
+        MyLOG.mConsoleService = Components.classes["@mozilla.org/consoleservice;1"]
                                     .getService(Components.interfaces
                                                           .nsIConsoleService);
     }
     
-    if (aPriority <= this.mVerbosity) {
+    if (aPriority <= MyLOG.mVerbosity) {
         if (aPriority == 0) {
             Components.utils.reportError(aMessage);
         } else {
-            this.mConsoleService.logStringMessage(aMessage);
+            MyLOG.mConsoleService.logStringMessage(aMessage);
         }
     }
 }
-MyLOG.prototype.mVerbosity = null;
-MyLOG.prototype.mConsoleService = null;
+MyLOG.mVerbosity = null;
+MyLOG.mConsoleService = null;
 
 
 /**
@@ -995,7 +995,7 @@ function md5(aString) {
 
     // convert the binary hash data to a hex string.
     var s = "";
-    for(i = 0; i < hash.length; i++) {
+    for(var i = 0; i < hash.length; i++) {
         s += hash.charCodeAt(i).toString(16);
     }
     


### PR DESCRIPTION
Apparently thunderbird 60 executes the extension code using strict mode. While most of the code worked fine, there were a few problems that lead to errors under strict mode. Now everything works under strict mode.

I also added `"use strict";` to all js files and a commit to bump the version.